### PR TITLE
add state utils for bytecode & storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,12 @@
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/tx": "^3.4.0",
         "@ethereumjs/vm": "^5.6.0",
+        "@polygon-hermez/test-vectors": "https://github.com/hermeznetwork/test-vectors.git",
         "chai": "^4.3.4",
         "circomlibjs": "^0.1.1",
         "ethers": "^5.5.4",
         "ffjavascript": "^0.2.46",
-        "test-vectors": "https://github.com/hermeznetwork/test-vectors.git"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "eslint": "^8.5.0",
@@ -27,14 +28,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
+      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.2.0",
+        "espree": "^9.3.1",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -841,6 +842,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@polygon-hermez/test-vectors": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/hermeznetwork/test-vectors.git#42b69fe6556a8a3e24c230728b4f97bb39200825",
+      "license": "ISC"
     },
     "node_modules/@types/abstract-leveldown": {
       "version": "7.2.0",
@@ -1741,12 +1747,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
+      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.0.5",
+        "@eslint/eslintrc": "^1.1.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1754,10 +1760,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.0",
+        "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.2.0",
-        "espree": "^9.3.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1923,9 +1929,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -1963,23 +1969,23 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3114,9 +3120,9 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3921,12 +3927,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/test-vectors": {
-      "name": "@polygon-hermez/test-vectors",
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/hermeznetwork/test-vectors.git#f68ce7d74aaae9388eaee998a71888710e82de6e",
-      "license": "ISC"
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4214,14 +4214,14 @@
   },
   "dependencies": {
     "@eslint/eslintrc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
+      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.2.0",
+        "espree": "^9.3.1",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -4727,6 +4727,10 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@polygon-hermez/test-vectors": {
+      "version": "git+ssh://git@github.com/hermeznetwork/test-vectors.git#42b69fe6556a8a3e24c230728b4f97bb39200825",
+      "from": "@polygon-hermez/test-vectors@https://github.com/hermeznetwork/test-vectors.git"
     },
     "@types/abstract-leveldown": {
       "version": "7.2.0",
@@ -5435,12 +5439,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
+      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.5",
+        "@eslint/eslintrc": "^1.1.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -5448,10 +5452,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.0",
+        "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.2.0",
-        "espree": "^9.3.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5589,9 +5593,9 @@
       }
     },
     "eslint-scope": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -5616,20 +5620,20 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "esquery": {
@@ -6483,9 +6487,9 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -7061,10 +7065,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "test-vectors": {
-      "version": "git+ssh://git@github.com/hermeznetwork/test-vectors.git#f68ce7d74aaae9388eaee998a71888710e82de6e",
-      "from": "test-vectors@https://github.com/hermeznetwork/test-vectors.git"
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "@ethereumjs/common": "^2.6.0",
     "@ethereumjs/tx": "^3.4.0",
     "@ethereumjs/vm": "^5.6.0",
+    "@polygon-hermez/test-vectors": "https://github.com/hermeznetwork/test-vectors.git",
     "chai": "^4.3.4",
     "circomlibjs": "^0.1.1",
     "ethers": "^5.5.4",
     "ffjavascript": "^0.2.46",
-    "test-vectors": "https://github.com/hermeznetwork/test-vectors.git"
+    "lodash": "^4.17.21"
   }
 }

--- a/src/state-utils.js
+++ b/src/state-utils.js
@@ -48,7 +48,89 @@ async function setAccountState(ethAddr, smt, root, balance, nonce) {
     return auxRes.newRoot;
 }
 
+/**
+ * Get the hash(bytecode) of a smart contract
+ * @param {String} ethAddr ethereum address
+ * @param {Object} smt merkle tree structure
+ * @param {Uint8Array} root merkle tree root
+ * @returns {String} hash(bytecode) represented as hexadecimal string
+ */
+async function getContractHashBytecode(ethAddr, smt, root) {
+    const keyContractCode = await smtUtils.keyContractCode(ethAddr, smt.arity);
+    const res = await smt.get(root, keyContractCode);
+
+    return res.value.toString(16).padStart(64, '0');
+}
+
+/**
+ * Set the bytecode of a smart contract
+ * @param {String} ethAddr ethereum address
+ * @param {Object} smt merkle tree structure
+ * @param {Uint8Array} root merkle tree root
+ * @param {String} bytecode smart contract bytecode represented as hexadecimal string
+ * @returns {Uint8Array} new state root
+ */
+async function setContractBytecode(ethAddr, smt, root, bytecode) {
+    const hashByteCode = await smtUtils.hashContractBytecode(bytecode);
+    const keyContractCode = await smtUtils.keyContractCode(ethAddr, smt.arity);
+
+    const res = await smt.set(root, keyContractCode, Scalar.fromString(hashByteCode, 16));
+
+    return res.newRoot;
+}
+
+/**
+ * Get the sorage values of a smart contract
+ * @param {String} ethAddr ethereum address
+ * @param {Object} smt merkle tree structure
+ * @param {Uint8Array} root merkle tree root
+ * @param {Array[String|Scalar]} storagePos smart contract storage position
+ * @returns {Object} mapping [storagePosition - value]
+ */
+async function getContractStorage(ethAddr, smt, root, storagePos) {
+    const res = {};
+
+    for (let i = 0; i < storagePos.length; i++) {
+        const pos = storagePos[i];
+        const keyStoragePos = await smtUtils.keyContractStorage(ethAddr, pos, smt.arity);
+        const resSMT = await smt.get(root, keyStoragePos);
+        res[(Scalar.e(pos)).toString()] = resSMT.value;
+    }
+
+    return res;
+}
+
+/**
+ * Set the storage of a smart contract address
+ * @param {String} ethAddr ethereum address
+ * @param {Object} smt merkle tree structure
+ * @param {Uint8Array} root merkle tree root
+ * @param {Object} storage [key-value] object containing [storagePos - stoValue]
+ * @returns {Uint8Array} new state root
+ */
+async function setContractStorage(ethAddr, smt, root, storage) {
+    let tmpRoot = root;
+
+    const storagePos = Object.keys(storage);
+
+    for (let i = 0; i < storagePos.length; i++) {
+        const pos = storagePos[i];
+        const value = storage[pos];
+
+        const keyStoragePos = await smtUtils.keyContractStorage(ethAddr, pos, smt.arity);
+
+        const auxRes = await smt.set(tmpRoot, keyStoragePos, Scalar.e(value));
+        tmpRoot = auxRes.newRoot;
+    }
+
+    return tmpRoot;
+}
+
 module.exports = {
     getState,
     setAccountState,
+    setContractBytecode,
+    setContractStorage,
+    getContractHashBytecode,
+    getContractStorage,
 };

--- a/test/helpers/test-utils.js
+++ b/test/helpers/test-utils.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { stateUtils } = require('../../index');
 
-const pathTestVectors = path.join(__dirname, '../../node_modules/test-vectors');
+const pathTestVectors = path.join(__dirname, '../../node_modules/@polygon-hermez/test-vectors');
 
 async function setGenesisBlock(addressArray, amountArray, nonceArray, smt) {
     let currentRoot = smt.F.zero;

--- a/test/smt-full-genesis.test.js
+++ b/test/smt-full-genesis.test.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+
+const {
+    MemDB, SMT, stateUtils, getPoseidon,
+} = require('../index');
+const { pathTestVectors } = require('./helpers/test-utils');
+
+describe('smt test vectors: key-genesis', async function () {
+    this.timeout(10000);
+    let poseidon;
+    let F;
+
+    let testVectors;
+
+    before(async () => {
+        poseidon = await getPoseidon();
+        F = poseidon.F;
+        testVectors = JSON.parse(fs.readFileSync(path.join(pathTestVectors, 'merkle-tree/smt-full-genesis.json')));
+    });
+
+    it('Should check test vectors', async () => {
+        // build tree and check root
+        for (let i = 0; i < testVectors.length; i++) {
+            const dataTest = testVectors[i];
+            const { arity, addresses, expectedRoot } = dataTest;
+
+            const db = new MemDB(F);
+            const smt = new SMT(db, arity, poseidon, poseidon.F);
+
+            let tmpRoot = F.zero;
+
+            for (let j = 0; j < addresses.length; j++) {
+                const {
+                    address, balance, nonce,
+                    bytecode, storage,
+                } = addresses[j];
+
+                // add balance and nonce
+                tmpRoot = await stateUtils.setAccountState(address, smt, tmpRoot, balance, nonce);
+
+                // add bytecode if defined
+                if (typeof bytecode !== 'undefined') {
+                    tmpRoot = await stateUtils.setContractBytecode(address, smt, tmpRoot, bytecode);
+                }
+
+                // add storage if defined
+                if (typeof storage !== 'undefined') {
+                    tmpRoot = await stateUtils.setContractStorage(address, smt, tmpRoot, storage);
+                }
+            }
+
+            expect(F.toString(tmpRoot)).to.be.equal(expectedRoot);
+        }
+    });
+});

--- a/test/state-utils.test.js
+++ b/test/state-utils.test.js
@@ -1,0 +1,69 @@
+/* eslint-disable quote-props */
+const { Scalar } = require('ffjavascript');
+const { expect } = require('chai');
+const lodash = require('lodash');
+
+const {
+    smtUtils, SMT, MemDB, getPoseidon, stateUtils,
+} = require('../index');
+
+// eslint-disable-next-line prefer-arrow-callback
+describe('smtUtils', async function () {
+    this.timeout(60000);
+
+    let poseidon;
+    let F;
+
+    before(async () => {
+        poseidon = await getPoseidon();
+        F = poseidon.F;
+    });
+
+    it('set-get account', async () => {
+        const db = new MemDB(F);
+        const smt = new SMT(db, 4, poseidon, poseidon.F);
+
+        const ethAddr = '0x12345';
+        const account = {
+            balance: Scalar.e('1000000000'),
+            nonce: Scalar.e('735'),
+        };
+
+        const root = await stateUtils.setAccountState(ethAddr, smt, F.zero, account.balance, account.nonce);
+        const resAccount = await stateUtils.getState(ethAddr, smt, root);
+
+        expect(account.balance.toString()).to.be.equal(resAccount.balance.toString());
+        expect(account.nonce.toString()).to.be.equal(resAccount.nonce.toString());
+    });
+
+    it('set-get hash bytecode', async () => {
+        const db = new MemDB(F);
+        const smt = new SMT(db, 4, poseidon, poseidon.F);
+
+        const ethAddr = '0x12345';
+        const bytecode = '0x6789A';
+        const hashBytecode = await smtUtils.hashContractBytecode(bytecode);
+
+        const root = await stateUtils.setContractBytecode(ethAddr, smt, F.zero, bytecode);
+        const resHashBytecode = await stateUtils.getContractHashBytecode(ethAddr, smt, root);
+
+        expect(hashBytecode).to.be.equal(resHashBytecode);
+    });
+
+    it('set-get contract storage', async () => {
+        const db = new MemDB(F);
+        const smt = new SMT(db, 4, poseidon, poseidon.F);
+
+        const ethAddr = '0x12345';
+        const storage = {
+            '873274': Scalar.e(23),
+            '7264': Scalar.e(57),
+            '2873': Scalar.e(77),
+        };
+
+        const root = await stateUtils.setContractStorage(ethAddr, smt, F.zero, storage);
+        const resStorage = await stateUtils.getContractStorage(ethAddr, smt, root, Object.keys(storage));
+
+        expect(lodash.isEqual(resStorage, storage)).to.be.equal(true);
+    });
+});


### PR DESCRIPTION
NOTE: This PR depends on another [test-vectors PR](https://github.com/hermeznetwork/test-vectors/pull/5) to completely fulfull the github actions

This PR does the following:
- add `setContractBytecode`,  `setContractStorage`, `getContractHashBytecode` & `getContractStorage` functionalities
- add test for those functionalities
- renames package `test-vectors` to `@polygon-hermez/test-vectors`
- add test for test-vector `smt-full-genesis.json` 