### PR TITLE
migrate mt-bridge

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,3 +10,5 @@ module.exports.TmpSmtDB = require('./src/tmp-smt-db');
 module.exports.utils = require('./src/utils');
 module.exports.ZkEVMDB = require('./src/zkevm-db');
 module.exports.getPoseidon = require('./src/poseidon');
+module.exports.MTBridge = require('./src/mt-bridge');
+module.exports.mtBridgeUtils = require('./src/mt-bridge-utils');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4226,7 +4226,7 @@
     "node_modules/zkevm-commonjs": {
       "name": "@polygon-hermez/zkevm-commonjs",
       "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git#b05d711dcdb4e8a83c825ff227163292a2478672",
+      "resolved": "git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git#b812def3221fd6ddd073c54c10f83e2d0e36a4b8",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/common": "^2.6.0",
@@ -7321,7 +7321,7 @@
       "dev": true
     },
     "zkevm-commonjs": {
-      "version": "git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git#b05d711dcdb4e8a83c825ff227163292a2478672",
+      "version": "git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git#b812def3221fd6ddd073c54c10f83e2d0e36a4b8",
       "from": "zkevm-commonjs@https://github.com/hermeznetwork/zkevm-commonjs",
       "requires": {
         "@ethereumjs/common": "^2.6.0",

--- a/src/mt-bridge-utils.js
+++ b/src/mt-bridge-utils.js
@@ -1,0 +1,54 @@
+const ethers = require('ethers');
+
+/**
+ * Calculate an array zero hashes of
+ * @param {Number} height - Merkle tree height
+ * @returns {Array} - Zero hashes array with length: height - 1
+ */
+function generateZeroHashes(height) {
+    const zeroHashes = [];
+    zeroHashes.push(ethers.constants.HashZero);
+    for (let i = 1; i < height; i++) {
+        zeroHashes.push(ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [zeroHashes[i - 1], zeroHashes[i - 1]]));
+    }
+    return zeroHashes;
+}
+
+/**
+ * Verify merkle proof
+ * @param {BigNumber} leaf - Leaf value
+ * @param {Array} smtProof - Array of sibilings
+ * @param {Number} index - Index of the leaf
+ * @param {BigNumber} root - Merkle root
+ * @returns {Boolean} - Whether the merkle proof is correct or not
+ */
+function verifyMerkleProof(leaf, smtProof, index, root) {
+    let value = leaf;
+    for (let i = 0; i < smtProof.length; i++) {
+        if (Math.floor(index / 2 ** i) % 2 !== 0) {
+            value = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [smtProof[i], value]);
+        } else {
+            value = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [value, smtProof[i]]);
+        }
+    }
+    return value === root;
+}
+
+/**
+ * Calculate leaf value
+ * @param {Number} originalNetwork - Original network
+ * @param {String} tokenAddress - Token address
+ * @param {BigNumber} amount - Amount of tokens
+ * @param {Number} destinationNetwork - Destination network
+ * @param {String} destinationAddress - Destination address
+ * @returns {Boolean} - Leaf value
+ */
+function calculateLeafValue(originalNetwork, tokenAddress, amount, destinationNetwork, destinationAddress) {
+    return ethers.utils.solidityKeccak256(['uint32', 'address', 'uint256', 'uint32', 'address'], [originalNetwork, tokenAddress, amount, destinationNetwork, destinationAddress]);
+}
+
+module.exports = {
+    generateZeroHashes,
+    verifyMerkleProof,
+    calculateLeafValue,
+};

--- a/src/mt-bridge.js
+++ b/src/mt-bridge.js
@@ -1,0 +1,66 @@
+const ethers = require('ethers');
+const { expect } = require('chai');
+const {
+    generateZeroHashes,
+} = require('./mt-bridge-utils');
+
+class MTBridge {
+    constructor(height) {
+        expect(height).to.be.greaterThan(1);
+        this.height = height;
+        this.zeroHashes = generateZeroHashes(height);
+        const tree = [];
+        for (let i = 0; i <= height; i++) {
+            tree.push([]);
+        }
+        this.tree = tree;
+        this.dirty = false;
+    }
+
+    add(leaf) {
+        this.dirty = true;
+        this.tree[0].push(leaf);
+    }
+
+    calcBranches() {
+        for (let i = 0; i < this.height; i++) {
+            const parent = this.tree[i + 1];
+            const child = this.tree[i];
+            for (let j = 0; j < child.length; j += 2) {
+                const leftNode = child[j];
+                const rightNode = (j + 1 < child.length) ? child[j + 1] : this.zeroHashes[i];
+                parent[j / 2] = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [leftNode, rightNode]);
+            }
+        }
+        this.dirty = false;
+    }
+
+    getProofTreeByIndex(index) {
+        if (this.dirty) this.calcBranches();
+        const proof = [];
+        let currentIndex = index;
+        for (let i = 0; i < this.height; i++) {
+            currentIndex = currentIndex % 2 === 1 ? currentIndex - 1 : currentIndex + 1;
+            if (currentIndex < this.tree[i].length) proof.push(this.tree[i][currentIndex]);
+            else proof.push(this.zeroHashes[i]);
+            currentIndex = Math.floor(currentIndex / 2);
+        }
+        return proof;
+    }
+
+    getProofTreeByValue(value) {
+        const index = this.tree[0].indexOf(value);
+        return this.getProofTreeByIndex(index);
+    }
+
+    getRoot() {
+        if (this.tree[0][0] === undefined) {
+            // No leafs in the tree, calculate root with all leafs to 0
+            return ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [this.zeroHashes[this.height - 1], this.zeroHashes[this.height - 1]]);
+        }
+        if (this.dirty) this.calcBranches();
+        return this.tree[this.height][0];
+    }
+}
+
+module.exports = MTBridge;

--- a/test/mt-bridge.test.js
+++ b/test/mt-bridge.test.js
@@ -1,0 +1,83 @@
+const { expect } = require('chai');
+const ethers = require('ethers');
+const { MTBridge } = require('../index');
+const {
+    verifyMerkleProof,
+} = require('../index').mtBridgeUtils;
+
+describe('Merkle Test', () => {
+    it('Check merkle tree', async () => {
+        const height = 32;
+        const merkleTree = new MTBridge(height);
+        const leafValue = ethers.utils.formatBytes32String('1');
+        merkleTree.add(leafValue);
+        const root = merkleTree.getRoot();
+        const proof = merkleTree.getProofTreeByIndex(0);
+        const index = 0;
+        const verification = verifyMerkleProof(leafValue, proof, index, root);
+        expect(verification).to.be.equal(true);
+    });
+
+    it('Check add 1 leaf to the merkle tree', async () => {
+        const height = 32;
+        const merkleTree = new MTBridge(height);
+
+        const leafValue = ethers.utils.formatBytes32String('123');
+        merkleTree.add(leafValue);
+
+        const root = merkleTree.getRoot();
+
+        // verify root
+        const zerHashesArray = merkleTree.zeroHashes;
+        let currentNode = leafValue;
+        for (let i = 0; i < height; i++) {
+            currentNode = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [currentNode, zerHashesArray[i]]);
+        }
+        expect(currentNode).to.be.equal(root);
+
+        // check merkle proof
+        const proof = merkleTree.getProofTreeByIndex(0);
+        const index = 0;
+        const verification = verifyMerkleProof(leafValue, proof, index, root);
+        expect(verification).to.be.equal(true);
+    });
+
+    it('Check add 1 leaf to the merkle tree', async () => {
+        const height = 32;
+        const merkleTree = new MTBridge(height);
+
+        const leafValue = ethers.utils.formatBytes32String('123');
+        const leafValue2 = ethers.utils.formatBytes32String('456');
+
+        merkleTree.add(leafValue);
+        merkleTree.add(leafValue2);
+
+        const root = merkleTree.getRoot();
+
+        // verify root;
+        const zerHashesArray = merkleTree.zeroHashes;
+        let currentNode = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [leafValue, leafValue2]);
+        for (let i = 1; i < height; i++) {
+            currentNode = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [currentNode, zerHashesArray[i]]);
+        }
+        expect(currentNode).to.be.equal(root);
+
+        // check merkle proof
+        const index = 0;
+        const proof = merkleTree.getProofTreeByIndex(index);
+        const verification = verifyMerkleProof(leafValue, proof, index, root);
+        expect(verification).to.be.equal(true);
+
+        // check merkle proof
+        const index2 = 1;
+        const proof2 = merkleTree.getProofTreeByIndex(index2);
+        const verification2 = verifyMerkleProof(leafValue2, proof2, index2, root);
+        expect(verification2).to.be.equal(true);
+
+        // following merkle proofs are invalid
+        expect(verifyMerkleProof(leafValue, proof2, index2, root)).to.be.equal(false);
+        expect(verifyMerkleProof(leafValue, proof2, index2, proof)).to.be.equal(false);
+        expect(verifyMerkleProof(leafValue, proof2, index2, proof)).to.be.equal(false);
+        expect(verifyMerkleProof(leafValue, proof2, index2 + 1, proof)).to.be.equal(false);
+    });
+});

--- a/test/poseidon.test.js
+++ b/test/poseidon.test.js
@@ -1,30 +1,37 @@
+/* eslint-disable prefer-arrow-callback */
 const { expect } = require('chai');
-
 const { performance } = require('perf_hooks');
 
+const { buildPoseidon } = require('circomlibjs');
 const {
     getPoseidon,
 } = require('../index');
 
-describe('getPoseidon', () => {
+describe('getPoseidon', async function () {
+    this.timeout(30000);
+    const numtimes = 5;
     let firstTime;
     let secondTime;
 
-    it('first get', async () => {
+    it('get 10 times poseidon from singleton', async () => {
         const startTime = performance.now();
-        await getPoseidon();
+        for (let i = 0; i < numtimes; i++) {
+            await getPoseidon();
+        }
         const stopTime = performance.now();
         firstTime = stopTime - startTime;
     });
 
-    it('second get', async () => {
+    it('get 10 times poseidon without singleton', async () => {
         const startTime = performance.now();
-        await getPoseidon();
+        for (let i = 0; i < numtimes; i++) {
+            await buildPoseidon();
+        }
         const stopTime = performance.now();
         secondTime = stopTime - startTime;
     });
 
     it('check times', async () => {
-        expect(firstTime).to.be.greaterThan(secondTime);
+        expect(secondTime).to.be.greaterThan(firstTime);
     });
 });


### PR DESCRIPTION
This PR does the following:
- update `package-lock.json`
- migrate from `contracts-zkEVM` the following modules
  - `merkle-tree-brisge.js` --> renamed to --> `mt-brisge.js`
  - `utils-merkle-tree-brisge.js` --> renamed to --> `mt-brisge-utils.js`
- improve test poseidon singleton 