### PR TITLE
fix version ethereumjs-monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xpolygonhermez/zkevm-commonjs",
   "description": "Javascript library implementing common utilities for zkevm",
-  "version": "0.5.0.1",
+  "version": "0.5.0.2",
   "main": "index.js",
   "scripts": {
     "setup": "npm i",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/0xPolygonHermez/zkevm-commonjs#readme",
   "devDependencies": {
-    "@0xpolygonhermez/contracts-zkevm": "github:0xPolygonHermez/zkevm-contracts#develop",
+    "@0xpolygonhermez/contracts-zkevm": "github:0xPolygonHermez/zkevm-contracts#v0.5.0.0",
     "@ethersproject/abi": "^5.6.4",
     "@nomiclabs/hardhat-ethers": "^2.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
@@ -50,7 +50,7 @@
     "@ethereumjs/block": "^3.6.2",
     "@ethereumjs/tx": "^3.4.0",
     "@polygon-hermez/common": "2.6.3",
-    "@polygon-hermez/vm": "5.7.27",
+    "@polygon-hermez/vm": "5.7.28",
     "ethereumjs-util": "^7.1.4",
     "ethers": "^5.5.4",
     "ffjavascript": "^0.2.55",


### PR DESCRIPTION
This PR does the following:
- fix version `@polygon-hermez/vm` where the opcode `extcodehash` was computed with an old `@0xpolygonhermez/zkevm-commonjs` version