### PR TITLE
Update vm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ethereumjs/block": "^3.6.2",
     "@ethereumjs/tx": "^3.4.0",
     "@polygon-hermez/common": "2.6.4",
-    "@polygon-hermez/vm": "5.7.39",
+    "@polygon-hermez/vm": "5.7.40",
     "ethereumjs-util": "^7.1.4",
     "ethers": "^5.5.4",
     "ffjavascript": "^0.2.55",


### PR DESCRIPTION
- Update `vm` dependency with new `modexp` error handling
  - `revert` when `modexp` byte size parameters is over 1024 bytes
  - do not consume gas when this limit is reached 