### PR TITLE
Feature/v6.3.0 fork.9

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -202,6 +202,17 @@ module.exports = class Processor {
             try {
                 const decodedObject = decodeCustomRawTxProverMethod(rawTx);
                 txDecoded = decodedObject.txDecoded;
+                /*
+                * The RLP encoding, encodes the 0 integer as "0x" ( empty byte array),
+                * In order to be compatible with Scalar or Number we will update the 0x integer cases with 0x00
+                */
+                const txParams = Object.keys(txDecoded);
+
+                txParams.forEach((key) => {
+                    if (txDecoded[key] === '0x' && key !== 'data' && key !== 'to') {
+                        txDecoded[key] = '0x00';
+                    }
+                });
                 rlpSignData = decodedObject.rlpSignData;
             } catch (error) {
                 this.decodedTxs.push({ isInvalid: true, reason: 'TX INVALID: Failed to RLP decode signing data', tx: txDecoded });
@@ -231,17 +242,6 @@ module.exports = class Processor {
                 continue;
             }
 
-            /*
-             * The RLP encoding, encodes the 0 integer as "0x" ( empty byte array),
-             * In order to be compatible with Scalar or Number we will update the 0x integer cases with 0x00
-             */
-            const txParams = Object.keys(txDecoded);
-
-            txParams.forEach((key) => {
-                if (txDecoded[key] === '0x' && key !== 'data' && key !== 'to') {
-                    txDecoded[key] = '0x00';
-                }
-            });
             this.decodedTxs.push({ isInvalid: false, reason: '', tx: txDecoded });
         }
     }

--- a/src/processor.js
+++ b/src/processor.js
@@ -773,7 +773,7 @@ module.exports = class Processor {
 
     async _processChangeL2BlockTx(tx) {
         // Reduce counters
-        this.vcm.computeFunctionCounters('processChangeL2Block');
+        this.vcm.computeFunctionCounters('processChangeL2Block', { verifyMerkleProof: tx.indexL1InfoTree !== 0 });
 
         // write old blockhash (oldStateRoot) on storage
         // Get old blockNumber

--- a/src/virtual-counters-manager.js
+++ b/src/virtual-counters-manager.js
@@ -25,7 +25,10 @@ module.exports = class VirtualCountersManager {
      * @param {Boolean} config.verbose - Activate or deactivate verbose mode, default: false
      */
     constructor(config = {}) {
-        this.totalSteps = config.steps || 2 ** 23;
+        this.configSteps = config.steps || 2 ** 23;
+        // safe guard counters to not take into account (%RANGE = 1 / SAFE_RANGE)
+        this.safeRange = config.safeRange || 20;
+        this.totalSteps = Math.floor(this.configSteps - this.configSteps / this.safeRange);
         this.verbose = config.verbose || false;
         this.consumptionReport = [];
         this.MCPReduction = config.MCPReduction || 0.6;


### PR DESCRIPTION
PR to fix som vcounters issues + vcounters improvements:

- Now at processChangeL2Block the flag verifyMerkleProof is passed to avoid computing the 32 keccaks of the MT
- New input config at VirtualCountersManager `config.steps` you can set the steps from config file. Default value 2**23
- New input config at VirtualCountersManager `config.MCPReduction` you can reduce the worst case scenario for vPoseidons, the default value is 0.6, we consider 0.6 a safe reduction of the worst case scenario, no OOCP has been detected on production yet.
- New feature consumptionReport -> for debuggging purposes
- Fixed bug at `opSha3`, wrong keccaks computation
- Fixed bug at `_opLog`, wrong `_opLogLoop` calls
- Reduced steps at `_mLoadX`, `_mstoreX`, `_mStore32`, `_mulArith`
- fix poseidon opAnd, opOr, opXor, opNot