### PR TITLE
add ability to rollback the bridge tree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/src/mt-bridge.js
+++ b/src/mt-bridge.js
@@ -16,11 +16,38 @@ class MTBridge {
         }
         this.tree = tree;
         this.dirty = false;
+
+        // Frontier
+        this.frontier = new Array(this.height).fill(ethers.constants.HashZero);
+        this.depositCount = 0;
+
+        // Historic frontiers. Index of the array is the depositCount
+        this.historicFrontiers = [];
+        this.saveFrontier();
     }
 
     add(leaf) {
         this.dirty = true;
         this.tree[0].push(leaf);
+        this.depositCount += 1;
+        this.computeFrontier(leaf);
+        this.saveFrontier();
+    }
+
+    computeFrontier(leaf) {
+        let node = leaf;
+
+        for (let i = 0; i < this.height; i++) {
+            if (((this.depositCount >> i) & 1) == 1) {
+                this.frontier[i] = node;
+                return;
+            }
+            node = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [this.frontier[i], node]);
+        }
+    }
+
+    saveFrontier() {
+        this.historicFrontiers.push(this.frontier.slice());
     }
 
     calcBranches() {
@@ -64,6 +91,40 @@ class MTBridge {
         if (this.dirty) this.calcBranches();
 
         return this.tree[this.height][0];
+    }
+
+    getRootFromFrontier(){
+        let node = ethers.constants.HashZero;
+
+        for (let i = 0; i < this.height; i++) {
+            if (((this.depositCount >> i) & 1) == 1) {
+                node = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [this.frontier[i], node]);
+            } else {
+                node = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [node, this.zeroHashes[i]]);
+            }
+        }
+
+        return node;
+    }
+
+    rollbackTree(depositCount) {
+        if (depositCount < 0 || depositCount > this.depositCount) {
+            throw new Error('MTBridge::rollbackTree: Invalid deposit count');
+        }
+
+        // Reset frontier and deposit count
+        this.depositCount = depositCount;
+        this.frontier = this.historicFrontiers[depositCount];
+        this.historicFrontiers = this.historicFrontiers.slice(0, depositCount);
+
+        // Reset leaves and tree
+        this.tree[0] = this.tree[0].slice(0, depositCount);
+        for (let i = 1; i <= this.height; i++) {
+            this.tree[i] = [];
+        }
+
+        // Recompute branches
+        this.calcBranches();
     }
 }
 

--- a/src/mt-bridge.js
+++ b/src/mt-bridge.js
@@ -38,8 +38,9 @@ class MTBridge {
         let node = leaf;
 
         for (let i = 0; i < this.height; i++) {
-            if (((this.depositCount >> i) & 1) == 1) {
+            if (((this.depositCount >> i) & 1) === 1) {
                 this.frontier[i] = node;
+
                 return;
             }
             node = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [this.frontier[i], node]);
@@ -93,11 +94,11 @@ class MTBridge {
         return this.tree[this.height][0];
     }
 
-    getRootFromFrontier(){
+    getRootFromFrontier() {
         let node = ethers.constants.HashZero;
 
         for (let i = 0; i < this.height; i++) {
-            if (((this.depositCount >> i) & 1) == 1) {
+            if (((this.depositCount >> i) & 1) === 1) {
                 node = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [this.frontier[i], node]);
             } else {
                 node = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [node, this.zeroHashes[i]]);

--- a/test/mt-bridge.test.js
+++ b/test/mt-bridge.test.js
@@ -130,7 +130,7 @@ describe('Merkle Bridge', () => {
 
         // add leaves (snaphot at middle)
         const numInsertions = 100;
-        const snapshot = Math.floor(numInsertions/2);
+        const snapshot = Math.floor(numInsertions / 2);
         let snapshotRoot;
         let snapshotDepositCount;
 
@@ -140,7 +140,7 @@ describe('Merkle Bridge', () => {
             leaves.push(leafValue);
             merkleTree.add(leafValue);
 
-            if (i == snapshot) {
+            if (i === snapshot) {
                 snapshotDepositCount = merkleTree.depositCount;
                 snapshotRoot = merkleTree.getRoot();
                 const rootFromFrontier = merkleTree.getRootFromFrontier();

--- a/test/mt-bridge.test.js
+++ b/test/mt-bridge.test.js
@@ -12,6 +12,11 @@ describe('Merkle Bridge', () => {
         const leafValue = ethers.utils.formatBytes32String('1');
         merkleTree.add(leafValue);
         const root = merkleTree.getRoot();
+
+        // check frontier
+        const rootFromFrontier = merkleTree.getRootFromFrontier();
+        expect(rootFromFrontier).to.be.equal(root);
+
         const proof = merkleTree.getProofTreeByIndex(0);
         const index = 0;
         const verification = verifyMerkleProof(leafValue, proof, index, root);
@@ -27,6 +32,10 @@ describe('Merkle Bridge', () => {
 
         const root = merkleTree.getRoot();
 
+        // check frontier
+        const rootFromFrontier = merkleTree.getRootFromFrontier();
+        expect(rootFromFrontier).to.be.equal(root);
+
         // verify root
         const zerHashesArray = merkleTree.zeroHashes;
         let currentNode = leafValue;
@@ -40,6 +49,9 @@ describe('Merkle Bridge', () => {
         const index = 0;
         const verification = verifyMerkleProof(leafValue, proof, index, root);
         expect(verification).to.be.equal(true);
+
+        // check depositCount
+        expect(merkleTree.depositCount).to.be.equal(1);
     });
 
     it('Check add multipple leafs to the merkle tree', async () => {
@@ -53,6 +65,10 @@ describe('Merkle Bridge', () => {
         merkleTree.add(leafValue2);
 
         const root = merkleTree.getRoot();
+
+        // check frontier
+        const rootFromFrontier = merkleTree.getRootFromFrontier();
+        expect(rootFromFrontier).to.be.equal(root);
 
         // verify root;
         const zerHashesArray = merkleTree.zeroHashes;
@@ -79,5 +95,75 @@ describe('Merkle Bridge', () => {
         expect(verifyMerkleProof(leafValue, proof2, index2, proof)).to.be.equal(false);
         expect(verifyMerkleProof(leafValue, proof2, index2, proof)).to.be.equal(false);
         expect(verifyMerkleProof(leafValue, proof2, index2 + 1, proof)).to.be.equal(false);
+
+        // check depositCount
+        expect(merkleTree.depositCount).to.be.equal(2);
+    });
+
+    it('Check rollback', async () => {
+        const height = 32;
+        const merkleTree = new MTBridge(height);
+
+        const leafValue = ethers.utils.formatBytes32String('123');
+        const leafValue2 = ethers.utils.formatBytes32String('456');
+
+        merkleTree.add(leafValue); // depositCount = 1
+        const firstRoot = merkleTree.getRoot();
+        merkleTree.add(leafValue2); // depositCount = 2
+        const secondRoot = merkleTree.getRoot();
+
+        // rollback
+        merkleTree.rollbackTree(1);
+        expect(merkleTree.getRoot()).to.be.equal(firstRoot);
+        expect(merkleTree.getRootFromFrontier()).to.be.equal(firstRoot);
+        expect(merkleTree.depositCount).to.be.equal(1);
+
+        merkleTree.add(leafValue2);
+        expect(merkleTree.getRoot()).to.be.equal(secondRoot);
+        expect(merkleTree.getRootFromFrontier()).to.be.equal(secondRoot);
+        expect(merkleTree.depositCount).to.be.equal(2);
+    });
+
+    it('Check rollback 100 leaves', async () => {
+        const height = 32;
+        const merkleTree = new MTBridge(height);
+
+        // add leaves (snaphot at middle)
+        const numInsertions = 100;
+        const snapshot = Math.floor(numInsertions/2);
+        let snapshotRoot;
+        let snapshotDepositCount;
+
+        const leaves = [];
+        for (let i = 0; i < numInsertions; i++) {
+            const leafValue = ethers.utils.formatBytes32String(i.toString());
+            leaves.push(leafValue);
+            merkleTree.add(leafValue);
+
+            if (i == snapshot) {
+                snapshotDepositCount = merkleTree.depositCount;
+                snapshotRoot = merkleTree.getRoot();
+                const rootFromFrontier = merkleTree.getRootFromFrontier();
+                expect(rootFromFrontier).to.be.equal(snapshotRoot);
+            }
+        }
+
+        // check root
+        const root = merkleTree.getRoot();
+        const rootFromFrontier = merkleTree.getRootFromFrontier();
+        expect(rootFromFrontier).to.be.equal(root);
+
+        // check depositCount
+        expect(merkleTree.depositCount).to.be.equal(numInsertions);
+        expect(merkleTree.historicFrontiers.length - 1).to.be.equal(numInsertions);
+
+        // rollback to snapshot
+        merkleTree.rollbackTree(snapshotDepositCount);
+
+        // check again root
+        const rootAfterRollback = merkleTree.getRoot();
+        const rootAfterRollbackFromFrontier = merkleTree.getRootFromFrontier();
+        expect(rootAfterRollback).to.be.equal(snapshotRoot);
+        expect(rootAfterRollbackFromFrontier).to.be.equal(snapshotRoot);
     });
 });


### PR DESCRIPTION
This PR does the following:
- compute `frontier` as in the SC
- get tree root from frontier
- saves historic frontiers
- adds ability to rollback the tree